### PR TITLE
Introduce layout restrictions on virtual table pointers stored in objects and VTTs

### DIFF
--- a/abi.html
+++ b/abi.html
@@ -1193,6 +1193,13 @@ and again excluding primary bases
 (which share virtual tables with the classes for which they are primary).
 </ul>
 
+<p>
+This ABI does not make guarantees about the layout of other virtual
+tables in a virtual table group relative to a virtual table pointer
+in an object or a VTT. It guarantees only the layout of the
+<a href="#mangling-special-vtables">global symbol</a> for that virtual table
+group. It does not guarantee that the virtual table pointers actually
+installed in an object or a VTT will point into that global symbol.
 
 <p>
 <a name="vtable-construction">
@@ -5756,6 +5763,9 @@ unwind table location.
 
 <h2><a name="revisions">Appendix R: Revision History</a></h2>
 <p> <hr>
+
+<p class="revision"><span class="date">[160907]</span>
+  Introduce layout restrictions on virtual table pointers stored in objects and VTTs.</p>
 
 <p class="revision"><span class="date">[151021]</span>
   Support transaction-safe functions.</p>


### PR DESCRIPTION
As discussed in cxx-abi-dev thread entitled "Proposing an ABI restriction
on loads from an object's vtable pointer".